### PR TITLE
Neuladen bei einer Subdomain sorgt nicht mehr für einen Fehler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /usr/share/nginx/html
 
 RUN rm -rf ./*
 COPY --from=build /app/dist ./
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
Neuladen bei einer Subdomain sorgt nicht mehr für einen "404 Not found" Error